### PR TITLE
twingate client:  -> 1.0.80

### DIFF
--- a/nixos/modules/services/networking/twingate.nix
+++ b/nixos/modules/services/networking/twingate.nix
@@ -8,7 +8,7 @@ let
 in {
 
   options.services.twingate = {
-    enable = mkEnableOption (lib.mdDoc "Twingate Client daemon");
+    enable = mkEnableOption "Twingate Client daemon";
   };
 
   config = mkIf cfg.enable {
@@ -19,7 +19,8 @@ in {
     environment.systemPackages = [ pkgs.twingate ]; # for the CLI
     systemd.packages = [ pkgs.twingate ];
 
-    systemd.services.twingate.preStart = ''
+    system.activationScripts.twingate = stringAfter ["etc"] ''
+      mkdir -p '/etc/twingate'
       cp -r -n ${pkgs.twingate}/etc/twingate/. /etc/twingate/
     '';
 

--- a/pkgs/applications/networking/twingate/default.nix
+++ b/pkgs/applications/networking/twingate/default.nix
@@ -8,19 +8,20 @@
 , udev
 , cryptsetup
 , stdenv
+, pkgs
 }:
 
 stdenv.mkDerivation rec {
   pname = "twingate";
-  version = "1.0.60";
+  version = "1.0.80+75934";
 
   src = fetchurl {
     url = "https://binaries.twingate.com/client/linux/DEB/${version}/twingate-amd64.deb";
-    sha256 = "b308c422af8a33ecd58e21a10a72c353351a189df67006e38d1ec029a93d5678";
+    sha256 = "3ec04f16941da8244bb913eb50644a7eb5806688666ebd1f587da193d55184b3";
   };
 
-  buildInputs = [ dbus curl libnl udev cryptsetup ];
-  nativeBuildInputs = [ dpkg autoPatchelfHook ];
+  buildInputs = [ curl libnl udev cryptsetup ];
+  nativeBuildInputs = [ dbus dpkg autoPatchelfHook ];
 
   unpackCmd = "mkdir root ; dpkg-deb -x $curSrc root";
 


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
